### PR TITLE
日本語モデルへの変更 / 検索文章を名詞のみに絞るロジック追加

### DIFF
--- a/junkyard/BertVectorSearch/app/cosin_sim_sample.py
+++ b/junkyard/BertVectorSearch/app/cosin_sim_sample.py
@@ -17,7 +17,7 @@ class OverviewSearch:
         self.use_saved_embeddings = use_saved_embeddings
         self.tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
         self.model = BertModel.from_pretrained('bert-base-uncased')
-        
+
         if self.use_saved_embeddings and self.embeddings_file and os.path.exists(self.embeddings_file):
             self.overview_embeddings, self.entries = self.load_embeddings_from_file(self.embeddings_file)
         else:
@@ -25,7 +25,7 @@ class OverviewSearch:
             self.overview_embeddings, self.entries = self.get_overview_embeddings(self.service_catalog)
             if self.embeddings_file:
                 self.save_embeddings_to_file(self.overview_embeddings, self.entries, self.embeddings_file)
-    
+
     def load_json_data(self, file_path):
         """JSONファイルを読み込む"""
         with open(file_path, 'r', encoding='utf-8') as f:
@@ -57,7 +57,7 @@ class OverviewSearch:
         """全ての概要をベクトル化する"""
         overview_embeddings = []
         entries = []
-        
+
         for service in service_catalog:
             overview_data = service.get("概要", {}).get("items", [])
             if isinstance(overview_data, list):
@@ -70,7 +70,7 @@ class OverviewSearch:
             if overview:
                 embedding = self.get_embedding(overview)
                 overview_embeddings.append(embedding)
-                
+
                 entry = {
                     'overview': overview,
                     'formal_name': service.get("正式名称", {}).get("items", ["N/A"])[0],
@@ -84,10 +84,10 @@ class OverviewSearch:
         """質問に最も類似した上位n件の概要を返す"""
         question_embedding = self.get_embedding(question)
         similarities = cosine_similarity(question_embedding, self.overview_embeddings)
-        
+
         # 上位n件のインデックスを取得
         top_n_indices = np.argsort(similarities[0])[-top_n:][::-1]
-        
+
         # 上位n件のエントリを返す
         top_n_results = [self.entries[i] for i in top_n_indices]
         return top_n_results

--- a/junkyard/BertVectorSearch/app/cosin_sim_sample.py
+++ b/junkyard/BertVectorSearch/app/cosin_sim_sample.py
@@ -15,8 +15,8 @@ class OverviewSearch:
         self.service_catalog_file = service_catalog_file
         self.embeddings_file = embeddings_file
         self.use_saved_embeddings = use_saved_embeddings
-        self.tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
-        self.model = BertModel.from_pretrained('bert-base-uncased')
+        self.tokenizer = BertTokenizer.from_pretrained('cl-tohoku/bert-base-japanese-v3')
+        self.model = BertModel.from_pretrained('cl-tohoku/bert-base-japanese-v3')
 
         if self.use_saved_embeddings and self.embeddings_file and os.path.exists(self.embeddings_file):
             self.overview_embeddings, self.entries = self.load_embeddings_from_file(self.embeddings_file)

--- a/junkyard/BertVectorSearch/app/requirements.txt
+++ b/junkyard/BertVectorSearch/app/requirements.txt
@@ -2,3 +2,5 @@ torch==2.0.1
 transformers==4.31.0
 scikit-learn==1.3.0
 numpy==1.25.0
+fugashi==1.3.2
+unidic-lite==1.0.8


### PR DESCRIPTION
20240824 Open Data Hackason 20240824中島作業分

## 変更内容
- ファイル内の余分なスペースを削除
- Bartモデルを日本語に強い`cl-tohoku/bert-base-japanese-v3`に変更
- MeCabを使用して質問と概要文章の名詞のみをベクトル検索対象にする様変更
  - こちらはあまり検索結果に影響がなかったので単語の一致などの指標を追加する必要あり