### PR TITLE
feat: improve service search workflow

### DIFF
--- a/SearchWebAPP/README.md
+++ b/SearchWebAPP/README.md
@@ -1,0 +1,76 @@
+# SearchWebAPP
+
+自治体サービス検索システムの Streamlit アプリケーションです。自治体が提供するサービスカタログを検索し、OpenAI API を活用してユーザーの質問意図に沿った情報を提示します。
+
+## 構成
+
+- `app/`
+  - `main.py`: Streamlit エントリーポイント。
+  - `catalog_utils.py`: サービスカタログの検索・ランキング処理。
+  - `conversation_graph.py`: LangGraph を使った対話制御ロジック。
+  - `llm_utils.py`: OpenAI Chat Completions API を用いた意図推定・推薦ロジック。
+  - `embed_utils.py`: OpenAI Embeddings API によるベクトル生成。
+  - `requirements.txt`: アプリで必要となる Python 依存関係。
+- `static/`
+  - `catalog_json/`: サービスカタログの JSON データ。
+  - `llm_service_json_prompt.txt`, `llm_service_select_prompt.txt`: LLM 向けプロンプトテンプレート。
+- `Dockerfile`, `docker-compose.yaml`: コンテナ開発用の設定。
+
+## 必要条件
+
+- Python 3.10 以降
+- OpenAI API キー (`OPENAI_API_KEY`)
+- ネットワーク接続（OpenAI API へアクセスするため）
+
+任意で以下の環境変数を設定できます。
+
+- `LLM_MODEL`: Chat Completions 用モデル名。既定値は `gpt-4o-mini`。
+- `OPENAI_EMBEDDING_MODEL`: Embeddings 用モデル名。既定値は `text-embedding-ada-002`。
+
+`.env` ファイルをプロジェクト直下（`SearchWebAPP/.env`）に作成すると、Streamlit 実行時や Docker コンテナ内で自動的に読み込まれます。
+
+```env
+OPENAI_API_KEY=sk-...
+LLM_MODEL=gpt-4o-mini
+OPENAI_EMBEDDING_MODEL=text-embedding-ada-002
+```
+
+## セットアップと実行
+
+### 1. ローカルで実行
+
+1. 依存関係をインストールします。
+   ```bash
+   cd SearchWebAPP
+   python -m venv .venv
+   source .venv/bin/activate  # Windows の場合は .venv\Scripts\activate
+   pip install -r app/requirements.txt
+   ```
+2. `.env` を準備し、OpenAI API キーなどを設定します。
+3. Streamlit でアプリを起動します。
+   ```bash
+   streamlit run app/main.py
+   ```
+4. ブラウザで <http://localhost:8501> にアクセスします。
+
+### 2. Docker / Docker Compose を利用
+
+Docker を用いるとローカル環境を汚さずに開発できます。
+
+1. `.env` を `SearchWebAPP/.env` に配置します。
+2. Docker イメージをビルドし、コンテナを起動します。
+   ```bash
+   cd SearchWebAPP
+   docker compose up --build
+   ```
+3. ブラウザで <http://localhost:8501> を開きます。
+
+開発中にホットリロードを有効にするため、`docker-compose.yaml` ではプロジェクトディレクトリを `/app` にマウントしています。
+
+## カタログデータの更新
+
+サービスカタログの JSON は `static/catalog_json/` 以下に格納されています。データを差し替える場合は同ディレクトリにあるファイルを更新し、再度アプリを起動してください。
+
+## ライセンス
+
+このリポジトリのルートにある `LICENSE` を参照してください。

--- a/SearchWebAPP/app/conversation_graph.py
+++ b/SearchWebAPP/app/conversation_graph.py
@@ -24,34 +24,14 @@ class GraphState(TypedDict):
 
 
 # -------------------------
-# （任意だが有効）簡易ヒューリスティック補正
-# -------------------------
-def _heuristic_labels(q: str) -> tuple[list, list]:
-    """単語ヒットで最低限のラベルを補強（LLMが外した際の保険）"""
-    tg: list = []
-    sv: list = []
-    if "定年" in q or "退職" in q:
-        tg.append("高齢者")
-    if "求人" in q or "就職" in q or "仕事" in q:
-        sv.append("雇用・就労支援")
-    return tg, sv
-
-
-# -------------------------
 # 既存: ラベル付け → 対象者が不明なら ask
 # -------------------------
 def classify_node(state: GraphState) -> GraphState:
     logger.info("ClassifyNode: question=%s", state["question"])
+    # ユーザーの質問に対して「対象者」と「該当サービス」のラベルを付与
     labels = label_question(state["question"])
     state["target_labels"] = labels.get("target_labels", []) or []
     state["service_labels"] = labels.get("service_labels", []) or []
-
-    # 簡易ヒューリスティック補正をマージ
-    ht, hs = _heuristic_labels(state["question"])
-    if ht:
-        state["target_labels"] = list({*state["target_labels"], *ht})
-    if hs:
-        state["service_labels"] = list({*state["service_labels"], *hs})
 
     logger.info(
         "ClassifyNode: targets=%s services=%s",

--- a/SearchWebAPP/app/conversation_graph.py
+++ b/SearchWebAPP/app/conversation_graph.py
@@ -1,11 +1,9 @@
-from __future__ import annotations
+# app/conversation_graph.py
 from typing import List, Optional, TypedDict
-
 import logging
 from langgraph.graph import StateGraph, END
 
-from llm_utils import label_question
-
+from llm_utils import label_question, IntentBuilder
 
 logger = logging.getLogger(__name__)
 
@@ -17,48 +15,182 @@ class GraphState(TypedDict):
     service_labels: List[str]
     action: str
     followup: Optional[str]
+    # フィードバック関連
+    feedback: Optional[str]        # "good"/"yes"/"positive" or "bad"/"no"/"negative"
+    refine_hint: Optional[str]
+    # 意図確定フロー
+    intent_sentence: Optional[str]
+    intent_confidence: Optional[float]
 
 
+# -------------------------
+# （任意だが有効）簡易ヒューリスティック補正
+# -------------------------
+def _heuristic_labels(q: str) -> tuple[list, list]:
+    """単語ヒットで最低限のラベルを補強（LLMが外した際の保険）"""
+    tg: list = []
+    sv: list = []
+    if "定年" in q or "退職" in q:
+        tg.append("高齢者")
+    if "求人" in q or "就職" in q or "仕事" in q:
+        sv.append("雇用・就労支援")
+    return tg, sv
+
+
+# -------------------------
+# 既存: ラベル付け → 対象者が不明なら ask
+# -------------------------
 def classify_node(state: GraphState) -> GraphState:
-    """Classify user question into target and service labels."""
     logger.info("ClassifyNode: question=%s", state["question"])
     labels = label_question(state["question"])
-    state["target_labels"] = labels.get("target_labels", [])
-    state["service_labels"] = labels.get("service_labels", [])
+    state["target_labels"] = labels.get("target_labels", []) or []
+    state["service_labels"] = labels.get("service_labels", []) or []
+
+    # 簡易ヒューリスティック補正をマージ
+    ht, hs = _heuristic_labels(state["question"])
+    if ht:
+        state["target_labels"] = list({*state["target_labels"], *ht})
+    if hs:
+        state["service_labels"] = list({*state["service_labels"], *hs})
+
     logger.info(
-        "ClassifyNode: target_labels=%s service_labels=%s",
-        state["target_labels"],
-        state["service_labels"],
+        "ClassifyNode: targets=%s services=%s",
+        state["target_labels"], state["service_labels"]
     )
     return state
 
 
 def decide_next(state: GraphState) -> GraphState:
-    """Decide whether to ask for target info or proceed to search."""
     targets = state.get("target_labels", [])
-    logger.info("DecideNode: targets=%s", targets)
-    # ask when target is missing or labeled as other/unknown
-    if (not targets) or any("その他" in t for t in targets):
+    # 対象者が欠損 or 「その他」を含む → まず対象者を確定
+    need_target = (not targets) or any("その他" in t for t in targets)
+    if need_target:
         state["action"] = "ask"
         state["followup"] = (
             "サービスを利用する対象者を教えてください。\n"
             "提供サービス、補助金や支援の対象を正確にご案内するために、サービス提供対象者のご家族や世帯の状況を教えていただけますか？\n"
             "例: 3歳の子がいる母親、高校生の子を持つ父親、65歳以上の一人暮らし など"
         )
-        logger.info("DecideNode: action=ask followup=%s", state["followup"])
+        logger.info("DecideNode: action=%s followup=%s", state["action"], bool(state.get("followup")))
     else:
-        state["action"] = "search"
+        # 対象者が明確 → 意図確定フェーズへ
+        state["action"] = "intent"
         state["followup"] = None
-        logger.info("DecideNode: action=search")
+        logger.info("DecideNode: action=%s followup=%s", state["action"], bool(state.get("followup")))
     return state
 
 
-# build LangGraph workflow
+# -------------------------
+# 追加: 意図確定ノード
+# -------------------------
+_intent_builder = IntentBuilder()
+
+def intent_node(state: GraphState) -> GraphState:
+    res = _intent_builder.build(state["question"])
+    state["intent_sentence"] = res.get("intent_sentence") or state["question"]
+    # LLM側が返したラベルを優先（空なら既存値を残す）
+    state["target_labels"] = res.get("target_labels") or state.get("target_labels", [])
+    state["service_labels"] = res.get("service_labels") or state.get("service_labels", [])
+    try:
+        state["intent_confidence"] = float(res.get("confidence") or 0.0)
+    except Exception:
+        state["intent_confidence"] = 0.0
+    state["followup"] = res.get("followup")
+    logger.info(
+        "IntentNode: sentence=%s, conf=%.2f, targets=%s, services=%s",
+        state["intent_sentence"], state["intent_confidence"]
+        if state["intent_confidence"] is not None else -1.0,
+        state["target_labels"], state["service_labels"]
+    )
+    return state
+
+
+def intent_decide_node(state: GraphState) -> GraphState:
+    conf = float(state.get("intent_confidence") or 0.0)
+    logger.info(
+        "IntentDecide: conf=%.2f labels(t=%s,s=%s)",
+        conf, state.get("target_labels"), state.get("service_labels")
+    )
+    if conf >= 0.7:
+        state["action"] = "search_intent"
+        state["followup"] = None
+        logger.info("IntentDecide: action=%s conf=%.2f", state["action"], conf)
+    else:
+        state["action"] = "ask_intent"
+        if not state.get("followup"):
+            state["followup"] = "どのような種類のサービス（例：補助金、手続き、相談、求人等）をお探しですか？"
+        logger.info("IntentDecide: action=%s conf=%.2f", state["action"], conf)
+    return state
+
+
+# -------------------------
+# グラフ定義（条件分岐ルーティングを厳密化）
+# -------------------------
 _graph = StateGraph(GraphState)
 _graph.add_node("classify", classify_node)
 _graph.add_node("decide", decide_next)
+_graph.add_node("intent", intent_node)
+_graph.add_node("intent_decide", intent_decide_node)
 _graph.set_entry_point("classify")
 _graph.add_edge("classify", "decide")
-_graph.add_edge("decide", END)
+
+# decide の結果に応じて次ノードを条件分岐
+def _route_from_decide(state: GraphState):
+    nxt = "intent" if state.get("action") == "intent" else "__end__"
+    logger.info("Router(decide): action=%s -> next=%s", state.get("action"), nxt)
+    return nxt
+
+_graph.add_conditional_edges(
+    "decide",
+    _route_from_decide,
+    {
+        "intent": "intent",
+        "__end__": END,   # action=ask のときはここで終了（main.py が追質問を提示）
+    },
+)
+
+_graph.add_edge("intent", "intent_decide")
+_graph.add_edge("intent_decide", END)
 
 workflow = _graph.compile()
+
+
+# -------------------------
+# Feedback-only workflow
+# -------------------------
+def _build_refine_followup(state: GraphState) -> str:
+    tgt = state.get("target_labels") or []
+    svc = state.get("service_labels") or []
+    base = "（対象者／サービス種別／オンライン手続き可否／費用・助成／時期・締切／地域・施設）"
+    if not tgt:
+        return (
+            "結果が期待と異なるようです。まず、サービスの対象者をもう少し詳しく教えてください。\n"
+            "例：3歳児の保護者／高校生の保護者／65歳以上の一人暮らし など\n"
+            f"併せて、優先したい条件があれば教えてください。{base}"
+        )
+    if not svc:
+        return (
+            "結果が期待と異なるようです。探しているサービスの種類（補助金・助成金、手続き、イベント等）を教えてください。\n"
+            f"また、優先したい条件があれば教えてください。{base}"
+        )
+    return f"どの点が期待と異なっていましたか？\n優先したい条件があれば教えてください。{base}"
+
+
+def feedback_node(state: GraphState) -> GraphState:
+    fb = (state.get("feedback") or "").lower()
+    if fb in {"good", "yes", "positive", "satisfied"}:
+        state["action"] = "end"
+        state["followup"] = None
+        return state
+    state["action"] = "ask"
+    state["followup"] = _build_refine_followup(state)
+    return state
+
+
+_feedback_graph = StateGraph(GraphState)
+_feedback_graph.add_node("feedback", feedback_node)
+_feedback_graph.set_entry_point("feedback")
+_feedback_graph.add_edge("feedback", END)
+
+feedback_workflow = _feedback_graph.compile()
+

--- a/SearchWebAPP/app/llm_utils.py
+++ b/SearchWebAPP/app/llm_utils.py
@@ -1,71 +1,197 @@
-"""OpenAI APIを用いたラベル分類とサービス選択"""
-from __future__ import annotations
-import os, json, logging
+# app/llm_utils.py
+import os
+import json
+from typing import List, Dict, Any
+
 from openai import OpenAI
+import logging
+
+# モデルは .env の LLM_MODEL で上書き可能（既定: gpt-4o-mini）
+DEFAULT_MODEL = os.getenv("LLM_MODEL", "gpt-4o-mini")
 
 logger = logging.getLogger(__name__)
+client = OpenAI()
 
-API_KEY = os.getenv("OPENAI_API_KEY")
-CHAT_MODEL = os.getenv("CHAT_MODEL", "gpt-3.5-turbo")
-client = OpenAI(api_key=API_KEY)
 
-PROMPT_PATH = os.path.join(os.path.dirname(__file__), "..", "static", "llm_service_json_prompt.txt")
-with open(PROMPT_PATH, "r", encoding="utf-8") as fp:
-    PROMPT_TEMPLATE = fp.read().rstrip() + "\n\n"
+# --------------------------------------------------------------------
+# ラベル付け：ユーザー質問から 対象者ラベル / サービスラベル を推定
+# 返り値: {"target_labels": [...], "service_labels": [...]}
+# --------------------------------------------------------------------
+def label_question(question: str) -> Dict[str, List[str]]:
+    system_prompt = (
+        "あなたは自治体サービス検索のラベリング係です。"
+        "入力文から『対象者ラベル』と『サービスラベル』を推定し、必ずJSONで返してください。"
+        "キーは target_labels と service_labels の2つです。"
+        "候補は以下のリストのみから選んでください。"
+        "\n\n"
+        "【対象者ラベル】\n"
+        "  乳幼児（0～2歳）, 未就学児（3歳〜小学校入学前）, 小学生, 中学生, 高校生, 大学生, "
+        "  保護者, 社会人, 高齢者, 障がい者, 事業者, 男性, 女性, どなたでも利用・参加可能, その他（該当が不明な場合）\n\n"
+        "【サービスラベル】\n"
+        "  補助金・助成金, 住まい・住宅支援, ペット・動物愛護, 水道・上下水道, 公園・緑地・レクリエーション, "
+        "  意見・要望・苦情受付, 健康・医療, 福祉・介護, 子育て・教育, 雇用・就労支援, 市民生活・手続き, 防災・災害対応, "
+        "  環境・ごみ・リサイクル, まちづくり・都市整備, 産業・事業者支援, 文化・スポーツ, 交通・移動支援, 移住・定住促進, "
+        "  男女共同参画・人権・相談, 行政運営・計画・評価, 選挙・政治参加, デジタル・IT関連, 消費生活・トラブル対応, その他\n"
+        "\n必ずJSONのみを出力してください。"
+    )
+    user_prompt = f"入力文: {question}"
 
-SELECT_PROMPT_PATH = os.path.join(os.path.dirname(__file__), "..", "static", "llm_service_select_prompt.txt")
-try:
-    with open(SELECT_PROMPT_PATH, "r", encoding="utf-8") as fp:
-        SELECT_PROMPT_TEMPLATE = fp.read().rstrip() + "\n\n"
-except FileNotFoundError:
-    SELECT_PROMPT_TEMPLATE = ""
-
-def label_question(question: str) -> dict:
-    messages = [
-        {"role": "user", "content": PROMPT_TEMPLATE + question}
-    ]
+    resp = client.chat.completions.create(
+        model=DEFAULT_MODEL,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        temperature=0,
+        response_format={"type": "json_object"},  # JSON を強制
+    )
+    content = (resp.choices[0].message.content or "").strip()
     try:
-        response = client.chat.completions.create(
-            model=CHAT_MODEL,
-            messages=messages,
-            temperature=0.2,
-            response_format={"type": "json_object"},
-            timeout=120,
-        )
-        content = response.choices[0].message.content
-        start, end = content.find("{"), content.rfind("}") + 1
-        return json.loads(content[start:end])
-    except Exception:
-        logger.exception("Failed to request label classification from OpenAI API")
-        raise
-
-class ServiceSelector:
-    """LLMを用いたサービス推薦"""
-    def __init__(self, max_select: int = 3):
-        self.max_select = max_select
-
-    def recommend(self, question: str, candidates: list[dict]) -> list[dict]:
-        payload = {
-            "question": question,
-            "candidates": candidates,
+        data = json.loads(content)
+        return {
+            "target_labels": data.get("target_labels", []) or [],
+            "service_labels": data.get("service_labels", []) or [],
         }
-        messages = [
-            {"role": "user", "content": SELECT_PROMPT_TEMPLATE + json.dumps(payload, ensure_ascii=False)}
-        ]
+    except Exception as e:
+        logger.warning("label_question JSON parse failed: %s | raw=%s", e, content[:300].replace("\n", " "))
+        return {"target_labels": [], "service_labels": []}
+
+
+# --------------------------------------------------------------------
+# 候補サービスから最大3件を選ぶセレクタ
+# candidates: [{"title": str, "url": str}, ...]
+# --------------------------------------------------------------------
+class ServiceSelector:
+    def __init__(self, model: str = DEFAULT_MODEL, top_k: int = 3):
+        self.model = model
+        self.top_k = top_k
+
+    def recommend(self, query: str, candidates: List[Dict[str, str]]) -> List[Dict[str, str]]:
+        prompt = (
+            "あなたは自治体サービスの案内係です。ユーザー質問に最も関連する候補を最大3件、"
+            "JSON で返してください。出力形式:\n"
+            '{"recommendations":[{"title":"...","url":"..."}, ...]}\n\n'
+            f"ユーザー質問: {query}\n\n候補:\n{json.dumps(candidates, ensure_ascii=False, indent=2)}"
+        )
+        resp = client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0,
+            response_format={"type": "json_object"},  # JSON を強制
+        )
+        content = (resp.choices[0].message.content or "").strip()
         try:
-            response = client.chat.completions.create(
-                model=CHAT_MODEL,
-                messages=messages,
-                temperature=0.2,
-                response_format={"type": "json_object"},
-                timeout=120,
-            )
-            content = response.choices[0].message.content
-            start, end = content.find("{"), content.rfind("}") + 1
-            data = json.loads(content[start:end])
-            recs = data.get("recommendations", [])
-            return recs[: self.max_select]
-        except Exception:
-            logger.exception("Failed to request service selection from OpenAI API")
+            parsed = json.loads(content)
+            recs = parsed.get("recommendations", []) or []
+            normed = []
+            for r in recs:
+                t = str(r.get("title", "")).strip()
+                u = r.get("url", "")
+                if t:
+                    normed.append({"title": t, "url": u if isinstance(u, str) else u})
+            return normed[: self.top_k]
+        except Exception as e:
+            logger.warning("ServiceSelector JSON parse failed: %s | raw=%s", e, content[:300].replace("\n", " "))
             return []
+
+
+# --------------------------------------------------------------------
+# 検索用「正規化1文」ビルダー
+# 返り値:
+#   {
+#     "intent_sentence": str,
+#     "target_labels": [str, ...],
+#     "service_labels": [str, ...],
+#     "confidence": float(0-1),
+#     "followup": str or None
+#   }
+#   ※ UI には出さず、LLMが生成したメッセージはログにINFOで出力する
+# --------------------------------------------------------------------
+class IntentBuilder:
+    def __init__(self, model: str = DEFAULT_MODEL):
+        self.model = model
+
+    def build(self, user_query: str) -> Dict[str, Any]:
+        system_prompt = (
+            "あなたは自治体サービス検索の案内係です。"
+            "ユーザー質問から、検索で使う代表的な1文（短く具体的）を作成し、"
+            "対象者ラベル・サービスラベルを付与し、確信度(0-1)を数値で返し、"
+            "不明瞭なら追質問を1つだけ生成してください。"
+            "必ずJSONのみを出力し、キーは intent_sentence, target_labels, service_labels, confidence, followup にしてください。"
+            "意図が明確なら followup は null にしてください。"
+            "\n\n"
+            "【対象者ラベル候補】\n"
+            "  乳幼児（0～2歳）, 未就学児（3歳〜小学校入学前）, 小学生, 中学生, 高校生, 大学生, "
+            "  保護者, 社会人, 高齢者, 障がい者, 事業者, 男性, 女性, どなたでも利用・参加可能, その他（該当が不明な場合）\n\n"
+            "【サービスラベル候補】\n"
+            "  補助金・助成金, 住まい・住宅支援, ペット・動物愛護, 水道・上下水道, 公園・緑地・レクリエーション, "
+            "  意見・要望・苦情受付, 健康・医療, 福祉・介護, 子育て・教育, 雇用・就労支援, 市民生活・手続き, 防災・災害対応, "
+            "  環境・ごみ・リサイクル, まちづくり・都市整備, 産業・事業者支援, 文化・スポーツ, 交通・移動支援, 移住・定住促進, "
+            "  男女共同参画・人権・相談, 行政運営・計画・評価, 選挙・政治参加, デジタル・IT関連, 消費生活・トラブル対応, その他\n"
+        )
+        user_prompt = (
+            f"ユーザー質問: {user_query}\n"
+            "注意: intent_sentence は実際に検索にかける代表文です。可能なら手続名や補助金名を具体化してください。"
+        )
+
+        resp = client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=0,
+            response_format={"type": "json_object"},  # JSON を強制
+        )
+        content = (resp.choices[0].message.content or "").strip()
+
+        # 解析とログ出力
+        try:
+            data = json.loads(content)
+        except Exception as e:
+            logger.warning("IntentBuilder JSON parse failed: %s | raw=%s", e, content[:300].replace("\n", " "))
+            # フォールバック（followup をログに出すため定型文を入れる）
+            data = {
+                "intent_sentence": user_query,
+                "target_labels": [],
+                "service_labels": [],
+                "confidence": 0.0,
+                "followup": "どのような種類のサービス（例：補助金、手続き、相談、求人等）をお探しですか？",
+            }
+
+        # 既定値補強
+        intent_sentence = data.get("intent_sentence") or user_query
+        target_labels = data.get("target_labels", []) or []
+        service_labels = data.get("service_labels", []) or []
+        confidence = data.get("confidence", 0.0)
+        followup = data.get("followup", None)
+
+        # 型整形
+        if isinstance(confidence, str):
+            try:
+                confidence = float(confidence)
+            except Exception:
+                confidence = 0.0
+
+        # ★ ここで「UIには出さずに」ログ出力する
+        # followup があればそのまま、なければ「検索用にこう解釈しました：intent_sentence」
+        if followup:
+            logger.info("[IntentBuilder msg] %s", str(followup))
+        else:
+            logger.info('[IntentBuilder msg] 検索用にこう解釈しました：「%s」', intent_sentence)
+
+        # 参考ログ（デバッグ用に要約も出す）
+        logger.info(
+            "IntentBuilder summary: sentence='%s' conf=%.2f targets=%s services=%s",
+            intent_sentence, confidence, target_labels, service_labels
+        )
+
+        # 呼び出し側が使えるように返却（UI 表示はしない）
+        return {
+            "intent_sentence": intent_sentence,
+            "target_labels": target_labels,
+            "service_labels": service_labels,
+            "confidence": confidence,
+            "followup": followup,
+        }
 

--- a/SearchWebAPP/app/main.py
+++ b/SearchWebAPP/app/main.py
@@ -1,118 +1,261 @@
-import os
-import sys
+# app/main.py
 import logging
+from typing import Dict, Any, List, Tuple
+
 import streamlit as st
 from dotenv import load_dotenv
 
-# ログ設定
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-logger = logging.getLogger(__name__)
-
-_CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(_CURRENT_DIR)
-
+from conversation_graph import workflow, feedback_workflow
+from catalog_utils import CatalogSearchEngine
 from embed_utils import embed_text
 from llm_utils import ServiceSelector
-from catalog_utils import CatalogSearchEngine
-from conversation_graph import workflow
 
+# -----------------------------------------------------------------------------
+# 初期設定
+# -----------------------------------------------------------------------------
 load_dotenv()
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
-st.set_page_config(page_title="自治体サービス案内チャット", page_icon="🏛️")
+st.set_page_config(page_title="自治体サービス検索", layout="wide")
+st.title("自治体サービス検索システム")
 
-# keep chat history between reruns
+# -----------------------------------------------------------------------------
+# セッション状態
+# -----------------------------------------------------------------------------
 if "history" not in st.session_state:
-    st.session_state.history = []  # list[(role, msg)]
+    st.session_state.history: List[Tuple[str, str]] = []
 if "pending_question" not in st.session_state:
     st.session_state.pending_question = ""
+if "awaiting_feedback" not in st.session_state:
+    st.session_state.awaiting_feedback = False
+if "refine_loops" not in st.session_state:
+    st.session_state.refine_loops = 0
+if "last_query" not in st.session_state:
+    st.session_state.last_query = ""
+if "last_labels" not in st.session_state:
+    st.session_state.last_labels = ([], [])
 
+# -----------------------------------------------------------------------------
+# ユーティリティ
+# -----------------------------------------------------------------------------
+def extract_url(val) -> str:
+    """service_catalog.json の URL 形式ゆらぎに耐える抽出器"""
+    if isinstance(val, str):
+        return val.strip()
+    if isinstance(val, list):
+        if val and isinstance(val[0], str):
+            return val[0].strip()
+        return ""
+    if isinstance(val, dict):
+        for k in ("items", "item", "url", "URL", "link", "links"):
+            if k in val:
+                v = val[k]
+                if isinstance(v, str):
+                    return v.strip()
+                if isinstance(v, list) and v and isinstance(v[0], str):
+                    return v[0].strip()
+    return ""
+
+def series_get(row, key, default=None):
+    try:
+        if hasattr(row, "get"):
+            return row.get(key, default)
+        return row[key] if key in row else default
+    except Exception:
+        return default
+
+def row_to_title_url(row) -> Tuple[str, str]:
+    title = series_get(row, "タイトル", "")
+    url_field = series_get(row, "URL", "")
+    url = extract_url(url_field)
+    title = str(title).strip() if title is not None else ""
+    return title, url
+
+# -----------------------------------------------------------------------------
+# 検索エンジン/セレクタ
+# -----------------------------------------------------------------------------
 searcher = CatalogSearchEngine()
 selector = ServiceSelector()
 
-# --- Render chat history (moved before form to ensure it's shown even if rerun/stop) ---
+# -----------------------------------------------------------------------------
+# チャット履歴の表示
+# -----------------------------------------------------------------------------
 for role, msg in st.session_state.history:
-    avatar = "🧑‍💻" if role == "user" else "🤖"
-    label  = "利用者" if role == "user" else "案内"
-    st.chat_message(f"{avatar} {label}", avatar=avatar).markdown(msg)
+    st.chat_message("user" if role == "user" else "assistant").write(msg)
 
-# --- Chat input form ---
-with st.form("chat_form", clear_on_submit=True):
-    user_msg = st.text_input("なんでも質問してください")
+# -----------------------------------------------------------------------------
+# 入力フォーム
+# -----------------------------------------------------------------------------
+with st.form("chat-form", clear_on_submit=True):
+    user_msg = st.text_input("質問を入力してください", "")
     submitted = st.form_submit_button("送信")
 
-# --- When user sends a message ---
+# -----------------------------------------------------------------------------
+# 送信処理
+# -----------------------------------------------------------------------------
 if submitted and user_msg:
     # 1) store user message
     st.session_state.history.append(("user", user_msg))
+    st.chat_message("user").write(user_msg)  # ★ その場で描画
     logger.info("Received user message: %s", user_msg)
 
-    # combine with pending question if we previously asked for target info
+    # combine with pending question if we previously asked for target/intent info
     combined_question = f"{st.session_state.pending_question} {user_msg}".strip()
-    logger.info(
-        "Combined question: '%s' (pending='%s')",
-        combined_question,
-        st.session_state.pending_question,
-    )
+    logger.info("Combined question: '%s' (pending='%s')",
+                combined_question, st.session_state.pending_question)
+    # 直近入力を保存
+    st.session_state.last_query = combined_question
 
-    # 2) classify using LangGraph workflow
+    # 2) LangGraph workflow
     try:
-        state = workflow.invoke({"question": combined_question, "target_labels": [], "service_labels": []})
+        state = workflow.invoke(
+            {"question": combined_question, "target_labels": [], "service_labels": []}
+        )
         logger.info("Workflow output: %s", state)
     except Exception:
-        logger.exception("label_question failed")
-        st.session_state.history.append(("assistant", "内部エラーが発生しました。時間を置いて再度お試しください。"))
+        logger.exception("workflow failed")
+        st.session_state.history.append(
+            ("assistant", "内部エラーが発生しました。時間を置いて再度お試しください。")
+        )
         st.rerun()
 
+    # 分岐1: 対象者が不明 -> 先に対象者確定
     if state["action"] == "ask":
-        # ask user to specify target
         st.session_state.pending_question = combined_question
-        logger.info("Action=ask pending_question set to: %s", st.session_state.pending_question)
+        logger.info("Action=ask pending_question='%s'", st.session_state.pending_question)
         st.session_state.history.append(("assistant", state["followup"]))
         st.rerun()
 
+    # 分岐2: 意図が不明 -> 意図確定のための1問
+    if state["action"] == "ask_intent":
+        st.session_state.pending_question = combined_question
+        logger.info("Action=ask_intent pending_question='%s'", st.session_state.pending_question)
+        st.session_state.history.append(("assistant", state.get("followup") or "もう少し詳しく教えてください。"))
+        st.rerun()
+
+    # ここに来るのは search_intent（意図確度高い） or intent確定後の通常検索
     st.session_state.pending_question = ""
+    intent_sentence = state.get("intent_sentence") or combined_question
     target_labels = state.get("target_labels", [])
     service_labels = state.get("service_labels", [])
-    logger.info(
-        "検索を実行: 対象者ラベル=%s サービスラベル=%s",
-        target_labels,
-        service_labels,
-    )
+    logger.info("SEARCH intent_sentence='%s'", intent_sentence)
+    logger.info("検索を実行: 対象者ラベル=%s サービスラベル=%s", target_labels, service_labels)
 
-    # 3) filter catalog by labels
+    st.session_state.last_labels = (target_labels, service_labels)
+    st.session_state.last_query = intent_sentence  # 検索に使った文として保存
+
+    # 3) カタログをラベルでフィルタ
     filtered_df = searcher.filter_by_labels(target_labels, service_labels)
+    logger.info("フィルター後のサービス件数: %s件", len(filtered_df))
 
-    # ログ出力: フィルター後の件数
-    logger.info(f"フィルター後のサービス件数: {len(filtered_df)}件")
-
-    # 4) BERT embed + similarity ranking (top 50)
-    query_vec = embed_text(combined_question)
+    # 4) 埋め込み + 類似度上位
+    query_vec = embed_text(intent_sentence)
     ranked_df = searcher.rank(filtered_df, query_vec, top_n=50)
 
-    # 5) craft assistant reply using LLM selection
-    if ranked_df.empty:
-        assistant_reply = "すみません、該当する自治体サービスが見つかりませんでした。別の表現でお試しください。"
-    else:
-        candidates = [
-            {"title": row["タイトル"], "url": row["URL"]["items"]}
-            for _, row in ranked_df.iterrows()
-        ]
-        try:
-            recs = selector.recommend(combined_question, candidates)
-        except Exception:
-            logger.exception("recommend failed")
-            recs = []
-        if recs:
-            services = "\n".join(
-                f"- **{r['title']}** ({r['url']})" for r in recs
-            )
-            assistant_reply = "おすすめのサービスはこちらです:\n" + services
+    # 5) 推薦/表示
+    header = f"**検索用にこう解釈しました：**「{intent_sentence}」"
+    try:
+        if ranked_df is None or len(ranked_df) == 0:
+            assistant_reply = header + "\n\nすみません、該当する自治体サービスが見つかりませんでした。別の表現でお試しください。"
         else:
-            top_rows = ranked_df.head(3)
-            services = "\n".join(
-                f"- **{row['タイトル']}** ({row['URL']['items']})" for _, row in top_rows.iterrows()
-            )
-            assistant_reply = "以下のサービスが見つかりました:\n" + services
+            # 候補を安全に構築
+            candidates = []
+            for _, row in ranked_df.iterrows():
+                t, u = row_to_title_url(row)
+                if t:
+                    candidates.append({"title": t, "url": u})
 
-    st.session_state.history.append(("assistant", assistant_reply))
-    st.rerun()
+            # LLM 推薦（失敗してもフォールバックで上位3件を出す）
+            recs = []
+            try:
+                recs = selector.recommend(intent_sentence, candidates) or []
+            except Exception:
+                logger.exception("recommend failed; fall back to top-3")
+
+            if recs:
+                lines = []
+                for r in recs:
+                    t = str(r.get("title", "")).strip()
+                    u = extract_url(r.get("url"))
+                    if t:
+                        lines.append(f"- **{t}** ({u})" if u else f"- **{t}**")
+                assistant_reply = header + ("\n\nおすすめのサービスはこちらです:\n" + "\n".join(lines)
+                                            if lines else "\n\nおすすめ候補を生成できませんでした。")
+            else:
+                # フォールバック: 上位3件
+                top_rows = ranked_df.head(3)
+                lines = []
+                for _, row in top_rows.iterrows():
+                    t, u = row_to_title_url(row)
+                    if t:
+                        lines.append(f"- **{t}** ({u})" if u else f"- **{t}**")
+                assistant_reply = header + ("\n\n以下のサービスが見つかりました:\n" + "\n".join(lines)
+                                            if lines else "\n\n候補が生成できませんでした。")
+
+        st.session_state.history.append(("assistant", assistant_reply))
+        st.chat_message("assistant").write(assistant_reply)  # ★ その場で描画
+        logger.info("Rendered %d services", assistant_reply.count("\n"))
+    except Exception:
+        logger.exception("Rendering services failed")
+        st.session_state.history.append(
+            ("assistant", header + "\n\n候補の表示でエラーが発生しました。入力条件を少し変えて再度お試しください。")
+        )
+
+    # 検索結果に対するフィードバックを受け付ける
+    st.session_state.awaiting_feedback = True
+    # rerunせず、このフレームでUIを描画
+
+# -----------------------------------------------------------------------------
+# 検索結果へのフィードバック処理
+# -----------------------------------------------------------------------------
+if st.session_state.get("awaiting_feedback", False):
+    st.divider()
+    st.info("この結果は役立ちましたか？")
+    col1, col2 = st.columns(2)
+    with col1:
+        fb_yes = st.button("はい、終了する", key="fb_yes")
+    with col2:
+        fb_no = st.button("いいえ、条件を絞り込む", key="fb_no")
+
+    if fb_yes:
+        # 終了
+        st.session_state.history.append(("assistant", "ご利用ありがとうございました。別の質問もどうぞ。"))
+        st.session_state.awaiting_feedback = False
+        st.session_state.refine_loops = 0
+        st.rerun()
+
+    if fb_no:
+        # ループ上限チェック
+        st.session_state.refine_loops += 1
+        if st.session_state.refine_loops >= 3:
+            st.session_state.history.append(
+                ("assistant", "うまく見つからないようです。担当窓口や有人チャットをご案内できます。続けますか？「続ける」または「終了」と入力してください。")
+            )
+            st.session_state.awaiting_feedback = False
+            st.rerun()
+
+        # フィードバックに基づく再絞り込み質問
+        try:
+            fb_state = feedback_workflow.invoke(
+                {
+                    "question": st.session_state.last_query,
+                    "target_labels": st.session_state.last_labels[0],
+                    "service_labels": st.session_state.last_labels[1],
+                    "feedback": "bad",
+                    "refine_hint": None,
+                }
+            )
+            followup = fb_state.get("followup") or (
+                "より具体的に条件を教えてください（対象者／サービス種別／オンライン手続き可否／費用・助成／時期・締切／地域・施設）。"
+            )
+        except Exception:
+            logger.exception("feedback_workflow failed")
+            followup = "より具体的に条件を教えてください（対象者／サービス種別／オンライン手続き可否／費用・助成／時期・締切／地域・施設）。"
+
+        st.session_state.pending_question = st.session_state.last_query  # 直前の意図文を保持
+        logger.info("ASK(by_feedback): pending='%s'", st.session_state.pending_question)
+        st.session_state.history.append(("assistant", followup))
+        st.session_state.awaiting_feedback = False
+        st.rerun()
+


### PR DESCRIPTION
- add LangGraph conversation flow with conditional routing (ask / intent / search)
- handle user feedback loop for refining search results
- log LLM-generated interpretation/follow-up messages (not shown in UI)
- fix import mismatch (ServiceSelector vs LLMServiceSelector)
- ensure chat messages render immediately in Streamlit (avoid missing results)
- add ServiceSelector.recommend_best(): pick best service from top-20 candidates